### PR TITLE
Disable physics in DefaultBlockIntegration

### DIFF
--- a/src/main/java/com/artillexstudios/axenvoy/integrations/blocks/impl/DefaultBlockIntegration.java
+++ b/src/main/java/com/artillexstudios/axenvoy/integrations/blocks/impl/DefaultBlockIntegration.java
@@ -12,14 +12,14 @@ public class DefaultBlockIntegration implements BlockIntegration {
     @Override
     public void place(String id, Location location) {
         Scheduler.get().executeAt(location, () -> {
-            location.getBlock().setType(Material.matchMaterial(id.toUpperCase(Locale.ENGLISH)));
+            location.getBlock().setType(Material.matchMaterial(id.toUpperCase(Locale.ENGLISH)), false);
         });
     }
 
     @Override
     public void remove(Location location) {
         Scheduler.get().executeAt(location, () -> {
-            location.getBlock().setType(Material.AIR);
+            location.getBlock().setType(Material.AIR, false);
         });
     }
 }


### PR DESCRIPTION
We should disable checking of the neighbor block interactions since neighbor blocks aren't related with envoy blocks.

Also it should prevent ticking the nearby blocks unnecessarily.