### PR TITLE
additional check to prevent block replacements

### DIFF
--- a/src/main/java/com/artillexstudios/axenvoy/config/impl/Config.java
+++ b/src/main/java/com/artillexstudios/axenvoy/config/impl/Config.java
@@ -14,6 +14,13 @@ public class Config extends AbstractConfig {
     })
     public static boolean LISTEN_TO_BLOCK_PHYSICS = false;
 
+    @Key("dont-replace-blocks")
+    @Comment({
+            "Enable this, if you want to prevent some blocks that",
+            "replaced by crates in certain cases."
+    })
+    public static boolean DONT_REPLACE_BLOCKS = true;
+
     private static final Config CONFIG = new Config();
 
     public static void reload() {

--- a/src/main/java/com/artillexstudios/axenvoy/envoy/SpawnedCrate.java
+++ b/src/main/java/com/artillexstudios/axenvoy/envoy/SpawnedCrate.java
@@ -6,6 +6,7 @@ import com.artillexstudios.axapi.scheduler.Scheduler;
 import com.artillexstudios.axapi.utils.placeholder.Placeholder;
 import com.artillexstudios.axapi.utils.placeholder.StaticPlaceholder;
 import com.artillexstudios.axenvoy.AxEnvoyPlugin;
+import com.artillexstudios.axenvoy.config.impl.Config;
 import com.artillexstudios.axenvoy.event.EnvoyCrateCollectEvent;
 import com.artillexstudios.axenvoy.integrations.blocks.BlockIntegration;
 import com.artillexstudios.axenvoy.rewards.Reward;
@@ -92,6 +93,12 @@ public class SpawnedCrate {
     }
 
     public void land(@NotNull Location location) {
+        if (Config.DONT_REPLACE_BLOCKS) {
+            while (!location.getBlock().getType().equals(Material.AIR) && !location.getBlock().getType().equals(Material.VOID_AIR) && !location.getBlock().getType().equals(Material.CAVE_AIR)) {
+                if (location.getY() >= location.getWorld().getMaxHeight()) break;
+                location.add(0, 1, 0);
+            }
+        }
         this.finishLocation = location;
         BlockIntegration.Companion.place(handle.getConfig().BLOCK_TYPE, location);
         this.updateHologram();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,3 +4,7 @@
 # Warning: This will probably tank your performance at crate spawning, if lots of crates spawn (lots = hundreds)
 # Changing this requires a restart!
 listen-to-block-physics: false
+
+# Enable this, if you want to prevent some blocks that
+# replaced by crates in certain cases.
+dont-replace-blocks: true


### PR DESCRIPTION
I added this because Vexes can passthrough the blocks and it causes to some blocks can be replaced by the crates.

This feature is plan B to place block above than the main block.

Its configurable and true by default.